### PR TITLE
Fix deprecated usage of woohoolabs-yin class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 composer.lock
 vendor
+
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ env:
         - PREFER_LOWEST="--prefer-lowest"
         - PREFER_LOWEST=""
 
+matrix:
+    allow_failures:
+        - env: PREFER_LOWEST="--prefer-lowest"
+
 install:
     composer update $PREFER_LOWEST
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ env:
         - PREFER_LOWEST=""
 
 install:
-    composer install $PREFER_LOWEST
+    composer update $PREFER_LOWEST
 
 script: composer test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 php:
     - '7.1'
     - '7.2'
-    - '7.3'
 
 env:
     matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,14 @@ language: php
 php:
     - '7.1'
     - '7.2'
+    - '7.3'
 
-install: composer install
+env:
+    matrix:
+        - PREFER_LOWEST="--prefer-lowest"
+        - PREFER_LOWEST=""
+
+install:
+    composer install $PREFER_LOWEST
 
 script: composer test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM php:7.1-alpine
+
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.DEFAULT_GOAL:help
+
+RUN?=docker run --rm --interactive --tty --volume ${PWD}:/app woohoolabs-yin-bundle
+
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m * make %s\033[0m ## %s\n", $$1, $$2}'
+
+build: ## Build image used to install dependencies and run tests
+	docker build --tag=woohoolabs-yin-bundle ${PWD}
+
+install: ## Install dependencies with docker
+	$(RUN) composer install
+
+test: ## Run phpspec tests
+	$(RUN) vendor/bin/phpspec run

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": "^7.1.0",
         "symfony/psr-http-message-bridge": "^1.0.2",
         "zendframework/zend-diactoros": "^1.3",
-        "woohoolabs/yin": "^3.0"
+        "woohoolabs/yin": "^3.1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.0",

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -11,14 +11,14 @@ use WoohooLabs\Yin\JsonApi\Exception\MediaTypeUnsupported;
 use WoohooLabs\Yin\JsonApi\Exception\QueryParamUnrecognized;
 use WoohooLabs\Yin\JsonApi\Hydrator\Relationship\ToManyRelationship;
 use WoohooLabs\Yin\JsonApi\Hydrator\Relationship\ToOneRelationship;
-use WoohooLabs\Yin\JsonApi\Schema\ResourceIdentifier;
-use WoohooLabs\Yin\JsonApi\Request\RequestInterface;
-use WoohooLabs\Yin\JsonApi\Request\Pagination\FixedPageBasedPagination;
-use WoohooLabs\Yin\JsonApi\Request\Pagination\PageBasedPagination;
-use WoohooLabs\Yin\JsonApi\Request\Pagination\OffsetBasedPagination;
+use WoohooLabs\Yin\JsonApi\Request\JsonApiRequestInterface;
 use WoohooLabs\Yin\JsonApi\Request\Pagination\CursorBasedPagination;
+use WoohooLabs\Yin\JsonApi\Request\Pagination\FixedPageBasedPagination;
+use WoohooLabs\Yin\JsonApi\Request\Pagination\OffsetBasedPagination;
+use WoohooLabs\Yin\JsonApi\Request\Pagination\PageBasedPagination;
+use WoohooLabs\Yin\JsonApi\Schema\ResourceIdentifier;
 
-class Request implements RequestInterface
+class Request implements JsonApiRequestInterface
 {
     /**
      * @var \Psr\Http\Message\ServerRequestInterface


### PR DESCRIPTION
`WoohooLabs\Yin\JsonApi\Request\RequestInterface` is now deprecated, we should use `\WoohooLabs\Yin\JsonApi\Request\JsonApiRequestInterface` instead.

Also add : 
 - Dockerfile and makefile to install and run test in docker environment
 - Travis matrix to tests with lowest and highest dependencies