### PR TITLE
Fix deprecated usage of woohoolabs-yin class

### DIFF
--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -11,14 +11,14 @@ use WoohooLabs\Yin\JsonApi\Exception\MediaTypeUnsupported;
 use WoohooLabs\Yin\JsonApi\Exception\QueryParamUnrecognized;
 use WoohooLabs\Yin\JsonApi\Hydrator\Relationship\ToManyRelationship;
 use WoohooLabs\Yin\JsonApi\Hydrator\Relationship\ToOneRelationship;
-use WoohooLabs\Yin\JsonApi\Schema\ResourceIdentifier;
-use WoohooLabs\Yin\JsonApi\Request\RequestInterface;
-use WoohooLabs\Yin\JsonApi\Request\Pagination\FixedPageBasedPagination;
-use WoohooLabs\Yin\JsonApi\Request\Pagination\PageBasedPagination;
-use WoohooLabs\Yin\JsonApi\Request\Pagination\OffsetBasedPagination;
+use WoohooLabs\Yin\JsonApi\Request\JsonApiRequestInterface;
 use WoohooLabs\Yin\JsonApi\Request\Pagination\CursorBasedPagination;
+use WoohooLabs\Yin\JsonApi\Request\Pagination\FixedPageBasedPagination;
+use WoohooLabs\Yin\JsonApi\Request\Pagination\OffsetBasedPagination;
+use WoohooLabs\Yin\JsonApi\Request\Pagination\PageBasedPagination;
+use WoohooLabs\Yin\JsonApi\Schema\ResourceIdentifier;
 
-class Request implements RequestInterface
+class Request implements JsonApiRequestInterface
 {
     /**
      * @var \Psr\Http\Message\ServerRequestInterface


### PR DESCRIPTION
WoohooLabs\Yin\JsonApi\Request\RequestInterface is now deprecated, we should use \WoohooLabs\Yin\JsonApi\Request\JsonApiRequestInterface instead.