### PR TITLE
Remove use of deprecation class.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,9 @@
         "php": "^7.1.0",
         "symfony/psr-http-message-bridge": "^1.0.2",
         "zendframework/zend-diactoros": "^1.3",
-        "woohoolabs/yin": "^3.0"
+        "woohoolabs/yin": "^3.0",
+        "nyholm/psr7": "^1.1",
+        "sensio/framework-extra-bundle": "^5.4"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.0",

--- a/spec/Factory/JsonApiFactorySpec.php
+++ b/spec/Factory/JsonApiFactorySpec.php
@@ -5,15 +5,15 @@ namespace spec\QP\WoohoolabsYinBundle\Factory;
 use PhpSpec\ObjectBehavior;
 use Psr\Http\Message\ServerRequestInterface;
 use QP\WoohoolabsYinBundle\Factory\JsonApiFactory;
-use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
+use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use WoohooLabs\Yin\JsonApi\JsonApi;
 use WoohooLabs\Yin\JsonApi\Exception\ExceptionFactoryInterface;
+use WoohooLabs\Yin\JsonApi\JsonApi;
 
 class JsonApiFactorySpec extends ObjectBehavior
 {
-    public function let(DiactorosFactory $psr7Factory, RequestStack $requestStack, Request $request, ServerRequestInterface $psrRequest, ExceptionFactoryInterface $exceptionFactory)
+    public function let(HttpMessageFactoryInterface $psr7Factory, RequestStack $requestStack, Request $request, ServerRequestInterface $psrRequest, ExceptionFactoryInterface $exceptionFactory)
     {
         $this->beConstructedWith($psr7Factory, $exceptionFactory);
         $requestStack->getCurrentRequest()->willReturn($request);

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -2,8 +2,8 @@
 
 namespace QP\WoohoolabsYinBundle\DependencyInjection;
 
-use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -5,16 +5,14 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
-        <parameter key="qp_woohoolabs_yin.psr7_factory.class">Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory</parameter>
         <parameter key="qp_woohoolabs_yin.json_api.class">WoohooLabs\Yin\JsonApi\JsonApi</parameter>
         <parameter key="qp_woohoolabs_yin.json_api.factory.class">QP\WoohoolabsYinBundle\Factory\JsonApiFactory</parameter>
         <parameter key="qp_woohoolabs_yin.exception_factory.default.class">WoohooLabs\Yin\JsonApi\Exception\DefaultExceptionFactory</parameter>
     </parameters>
     <services>
         <service id="qp_woohoolabs_yin.exception_factory.default" class="%qp_woohoolabs_yin.exception_factory.default.class%"/>
-        <service id="qp_woohoolabs_yin.psr7_factory" class="%qp_woohoolabs_yin.psr7_factory.class%" public="false"/>
         <service id="qp_woohoolabs_yin.json_api.factory" class="%qp_woohoolabs_yin.json_api.factory.class%" public="false">
-            <argument type="service" id="qp_woohoolabs_yin.psr7_factory"/>
+            <argument type="service" id="sensio_framework_extra.psr7.http_message_factory"/>
             <argument type="service" id="qp_woohoolabs_yin.exception_factory"/>
         </service>
         <service id="qp_woohoolabs_yin.json_api" class="%qp_woohoolabs_yin.json_api.class%">


### PR DESCRIPTION
By requiring `sensio/framework-extra-bundle`, symfony application can now transform a PSR7 `ResponseInterface` into a `HttpFoundation\Response` which has to be returned by Symfony's controller.