### PR TITLE
Remove unused dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
     "require": {
         "php": "^7.1.0",
         "symfony/psr-http-message-bridge": "^1.0.2",
-        "zendframework/zend-diactoros": "^1.3",
         "woohoolabs/yin": "^3.0",
         "nyholm/psr7": "^1.1",
         "sensio/framework-extra-bundle": "^5.4"

--- a/src/Factory/JsonApiFactory.php
+++ b/src/Factory/JsonApiFactory.php
@@ -2,12 +2,12 @@
 
 namespace QP\WoohoolabsYinBundle\Factory;
 
+use Nyholm\Psr7\Response;
 use QP\WoohoolabsYinBundle\Request\Request as JsonApiRequest;
 use Symfony\Bridge\PsrHttpMessage\HttpMessageFactoryInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use WoohooLabs\Yin\JsonApi\Exception\ExceptionFactoryInterface;
 use WoohooLabs\Yin\JsonApi\JsonApi;
-use Zend\Diactoros\Response;
 
 /**
  * @author Quentin <quentin.pautrat@gmail.com>


### PR DESCRIPTION
By replacing deprecated class in #14 we do not need `zendframework/zend-diactoros` dependency anymore.
Instead we use `nyholm/psr7` which is used by `sensio/framework-extra-bundle`.