### PR TITLE
Fixed TreeBuilder::root() symfony 4.3 deprecation

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -14,8 +14,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('qp_woohoolabs_yin');
+        $treeBuilder = new TreeBuilder('qp_woohoolabs_yin');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -15,7 +15,13 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('qp_woohoolabs_yin');
-        $rootNode = $treeBuilder->getRootNode();
+
+        if (\method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('qp_woohoolabs_yin');
+        }
 
         $rootNode
             ->children()


### PR DESCRIPTION
The "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method called for the "qp_woohoolabs_yin" configuration is deprecated since Symfony 4.3, pass the root name to the constructor instead