### PR TITLE
Add support for PHP 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1-alpine
+FROM php:8.0-alpine
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 

--- a/composer.json
+++ b/composer.json
@@ -11,16 +11,16 @@
         }
     ],
     "require": {
-        "php": "^7.1.0",
+        "php": "^7.1.0 || ^8.0",
         "psr/http-factory": "^1.0",
         "sensio/framework-extra-bundle": "^5.4",
-        "symfony/psr-http-message-bridge": "^1.2",
+        "symfony/psr-http-message-bridge": "^1.2 || ^2.1",
         "woohoolabs/yin": "^4.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.0",
         "nyholm/psr7": "^1.2",
-        "phpspec/phpspec": "^4.3"
+        "phpspec/phpspec": "^4.3 || ^7.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I have update the composer file and Dockerfile to support PHP 8. The `make test` did succeed, so there should be no breaking changes.

Not sure how to handle the Dockerfile though, perhaps multiple stages can be added (i.e. one for php7.1 and one for php8)? The `make build` command could be passed the PHP version to build? Feedback is welcome regarding that.

It would be very nice if this could be merged, so we can at least use this package with PHP 8.